### PR TITLE
Fix sample program in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ You could create a CLI file like this:
 
 ```php
 <?php
+include "functions.php";
+
+$debug             = false;
+$lookahead         = 5;   //    
+$pos_error         = 0.1; // absolute
+$alignment_error   = 0.01; // absolute  
+$extrusion_error   = 0.15; // percent       
+$start             = microtime(true);
 
 $options = getopt('f:o:');
 


### PR DESCRIPTION
I have added the initialization code (one include and 6 variable declarations) to the example program for GCodeArcOptimizer be used via command-line. Only after I did that it worked. This solves issue #2.